### PR TITLE
make platinum easier to see (add green stripes)

### DIFF
--- a/src/css/protondbCard.css
+++ b/src/css/protondbCard.css
@@ -24,7 +24,13 @@
 }
 
 .proton_platinum {
-    background: rgb(180, 199, 220);
+    background: repeating-linear-gradient(
+        45deg,
+        rgb(0, 128, 0),
+        rgb(0, 128, 0) 7px,
+        rgb(180, 199, 220) 7px,
+        rgb(180, 199, 220) 14px
+    );
     transition: 0.1s;
 }
 


### PR DESCRIPTION
This is a handy extension. Unfortunately, when I tried to use it I found it hard to see the difference between platinum and silver when scanning search results. So I figured I'd contribute a candidate fix, although feel free to throw away my actual fix CSS & come up with a better idea that solves the underlying problem.

Basically I wanted to keep the existing platinum color, but also add something else to make it more visually distinct, so I said "idk, stripes?" I found this & basically stole it: https://css-tricks.com/stripes-css/.

Arguably it looks kind of ugly and slightly reduces readability (I'm not really a CSS guy). But it does make it easier to notice platinum results in search