### PR TITLE
Fix firefox issue with CORS requests

### DIFF
--- a/build/manifests/information.json
+++ b/build/manifests/information.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "app_version": 1.5,
+    "app_version": "1.5.3",
     "app_name": "ProtonDB for Steam",
     "app_description": "Adds the ProtonDB rating to games in the Steam store so you get an idea of how it will run before you buy it!",
     "host_permissions": ["https://www.protondb.com/*"],

--- a/build/manifests/information.json
+++ b/build/manifests/information.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "app_version": "1.5.3",
+    "app_version": "1.6",
     "app_name": "ProtonDB for Steam",
     "app_description": "Adds the ProtonDB rating to games in the Steam store so you get an idea of how it will run before you buy it!",
     "host_permissions": ["https://www.protondb.com/*"],

--- a/build/manifests/manifest.firefox.json
+++ b/build/manifests/manifest.firefox.json
@@ -4,6 +4,7 @@
     "name": "{app_name}",
     "description": "{app_description}",
     "host_permissions": {host_permissions},
+    "permissions": {host_permissions},
     "background": {
         "scripts": ["{background_script}"]
     },


### PR DESCRIPTION
I totally forgot to push this fix. It really only adds the websites to the permissions tag for firefox, which allows the extension to make requests to protondb. Woops