### PR TITLE
Resolve firefox not asking for permission

### DIFF
--- a/build/manifests/information.json
+++ b/build/manifests/information.json
@@ -1,6 +1,6 @@
 {
     "manifest_version": 3,
-    "app_version": "1.6.1",
+    "app_version": "1.6.3",
     "app_name": "ProtonDB for Steam",
     "app_description": "Adds the ProtonDB rating to games in the Steam store so you get an idea of how it will run before you buy it!",
     "host_permissions": ["https://www.protondb.com/*"],

--- a/build/manifests/manifest.firefox.json
+++ b/build/manifests/manifest.firefox.json
@@ -11,5 +11,7 @@
     "content_scripts": {content_scripts},
     "browser_specific_settings": {
         "gecko": {firefox}
-    }
+    },"action": {
+        "default_popup": "html/permissions.html"
+      }
 }

--- a/build/manifests/manifest.firefox.json
+++ b/build/manifests/manifest.firefox.json
@@ -11,7 +11,5 @@
     "content_scripts": {content_scripts},
     "browser_specific_settings": {
         "gecko": {firefox}
-    },"action": {
-        "default_popup": "html/permissions.html"
-      }
+    }
 }

--- a/src/css/permission_page.css
+++ b/src/css/permission_page.css
@@ -1,0 +1,24 @@
+body{
+    background-color: #20232B;
+    color: white;
+    padding: 5vh 30vw;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: large;
+}
+
+.btn-toggle{
+    display: inline-block;
+    padding: 10px 20px;
+    font-size: 18px;
+    cursor: pointer;
+    text-align: center;
+    text-decoration: none;
+    outline: none;
+    color: #fff;
+    background-color: #6e6e6e;
+    border: none;
+    border-radius: 15px;
+    box-shadow: 0 5px rgb(245, 0, 87);
+}
+
+.btn-toggle:hover {background-color: #313131;  box-shadow: 0 5px rgb(151, 0, 53);}

--- a/src/html/permissions.html
+++ b/src/html/permissions.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>ProtonDB For Steam - Extension Permissions</title>
+</head>
+<body>
+  <h1 style="color: rgb(245, 0, 87)">ProtonDB For Steam <Empty style="color: white">- Permission Required</Empty></h1>
+  <h3>Hello Dear User!</h3>
+  <p>Recently, we updated to Manifest V3. 
+  Unfortunately, that removed the ability for <i>required</i> web permissions<br>
+  Our extension <b>needs</b> access to the steam website and protondb website to work.<br><br>
+  The reason for this is that we retrieve the scores from protondb. And ofcourse, to show you the rating, we need to be able to change the steam page.
+  That's all we do, we promise. You can always check the source code on <a href="https://github.com/MostwantedRBX/proton-chrome-extension" target="_blank">the github page</a>, with the option of building it yourself.<br>
+  Still, it's your choice to grant us these permissions. If you do, you always have the ability to revoke them immediately.
+  Keep in mind, we do <b>need</b> those permissions for this extension to do anything. You can grant us these permissions by clicking the button below and confirming the popup above.
+  <br>
+  <b><h3>So, to get started: Press the button below to grant the required permissions.</h3></b>
+  <button id="request-permission" class="btn-toggle">Grant Permissions</button>
+  <script src="../js/permissions.js"></script>
+  <link rel="stylesheet" href="../css/permission_page.css">
+</body>
+</html>

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -24,3 +24,25 @@ chrome.runtime.onMessage.addListener(
       }
   }
 );
+/// This function checks if the current browser is firefox and if so, opens a special permissions tab requesting permissions.
+/// Firefox has stopped supporting 'required' permissions since v3 and is real picky with asking the user about those permissions.
+/// This opens a page explaining the permissions and asking for a button click
+function onStartup(){
+    if (typeof browser !== 'undefined' && browser.runtime.getBrowserInfo) {
+        if(browser.runtime.getBrowserInfo().then(async function(res){
+            console.log(res);
+            if(res.name == "Firefox"){
+                browser.permissions.contains({origins: ['https://www.protondb.com/*', 'https://store.steampowered.com/*']}).then(async function(result) {
+                    if(!result){
+                        await browser.tabs.create({ url: "html/permissions.html" });
+                    }
+                });
+            }
+        }));
+    }
+}
+
+chrome.runtime.onInstalled.addListener(async (details) => {
+    onStartup();
+});
+

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -30,7 +30,6 @@ chrome.runtime.onMessage.addListener(
 function onStartup(){
     if (typeof browser !== 'undefined' && browser.runtime.getBrowserInfo) {
         if(browser.runtime.getBrowserInfo().then(async function(res){
-            console.log(res);
             if(res.name == "Firefox"){
                 browser.permissions.contains({origins: ['https://www.protondb.com/*', 'https://store.steampowered.com/*']}).then(async function(result) {
                     if(!result){

--- a/src/js/permissions.js
+++ b/src/js/permissions.js
@@ -1,0 +1,11 @@
+document.getElementById('request-permission').addEventListener('click', () => {
+    browser.permissions.request({
+      origins: ['https://www.protondb.com/*', 'https://store.steampowered.com/*']
+    }).then((granted) => {
+      if (granted) {
+        window.close();
+      } 
+    }).catch((error) => {
+      console.error(error);
+    });
+  });


### PR DESCRIPTION
Alright, this is a long one.

Since manifest v3, firefox has no support anymore for 'required host permissions'. This means that access to the steam pages and protondb are entirely optional. Even worse, they are disabled by default and the users are NOT prompted about these permissions(as far as I could see). 

There was no good way to do this either, as asking for permissions has to be done after a user interaction.
To resolve this, I added some firefox-specific code. It does the following.

After the extension has been installed, it checks if it has the required permissions(hardcoded atm).
If it does not, it opens a new tab. This tab explains the permissions, why we need them and that the extension simply doens't work without it. It has a button that, when pressed, forces firefox to ask the user for the required permissions.

If they agree, the webpage closes and the extension now works.

This is what the page currently looks like:
![image](https://user-images.githubusercontent.com/39661332/227846878-0a3c798c-9bde-48d3-b611-2f9905a84d83.png)

Obviously change whatever you want about this PR. I just thought it was necessary, as firefox users currently probably think the extension is broken(since the permissions are disabled by default).